### PR TITLE
Added mipmapping to replace slow supersampling

### DIFF
--- a/usr/modules/EarthTessellationModule/mm/shaders/earth.geom
+++ b/usr/modules/EarthTessellationModule/mm/shaders/earth.geom
@@ -2,102 +2,35 @@
 layout (triangles) in;
 layout (line_strip, max_vertices = 4) out;
 
-in vec2 vTPos2[];
+in vec3 vTLPos[];
+in vec4 vTPos2[];
+in float vTLat[];
 
 out vec3 fPos;
 out float fLat;
 
-uniform mat4 MVPMat;
-uniform float scale;
-
-uniform isampler2D elevationTexture;
-
-// constants used in conversion from WGS84
-const float EARTH_RADIUS = 6378137.0;
-const float EARTH_FLATTENING = 0.00669437999013;
-const float PI = 3.14159265358979323846;
-
-// convert from WGS84 to ECEF
-vec3 WGS84ToECEF(vec3 v) {
-	float latRad = v.x;
-	float lonRad = v.y;
-	float elev = v.z * scale;
-
-	float sinLatRad = sin(latRad);
-	float e2sinLatSq = EARTH_FLATTENING * (sinLatRad * sinLatRad);
-
-	float rn = EARTH_RADIUS * scale / sqrt(1 - e2sinLatSq);
-	float R = (rn + elev) * cos(latRad);
-
-	vec3 o;
-	o.x = R * cos(lonRad);
-	o.y = R * sin(lonRad);
-	o.z = (rn * (1 - EARTH_FLATTENING) + elev) * sin(latRad);
-
-	return o;
-}
-
-// super-sample elevation texture at UV coordinate
-float getElev(vec2 uv) {
-	float elev = 0;
-	float amntX = 1.0 / 64.0 / 180.0;
-	float amntY = amntX / 2.0;
-
-	// take 25 samples and average them
-	for (int i = 0; i < 5; ++i) {
-		for (int j = 0; j < 5; ++j) {
-			vec2 new_uv;
-			new_uv.x = uv.x + mix(-amntX, amntX, float(i) / 4.0);
-			new_uv.y = uv.y + mix(-amntY, amntY, float(j) / 4.0);
-
-			elev += float(textureLod(elevationTexture, new_uv, 10.0).r);
-		}
-	}
-	elev /= 25.0;
-
-	return elev * 10.0;
-}
-
-// convert WGS84 to UV space of elevation texture
-vec2 WGS84ToUV(vec2 v) {
-	vec2 uv;
-	uv.x = (v.y + PI) / (2 * PI);
-	uv.y = (PI / 2 - v.x) / PI;
-	return uv;
-}
-
 void main() {
-	// get UV coordinates for each vertex of triangle
-	vec2 uv0 = WGS84ToUV(vTPos2[0]);
-	vec2 uv1 = WGS84ToUV(vTPos2[1]);
-	vec2 uv2 = WGS84ToUV(vTPos2[2]);
-
-	// get ECEF coordinates for each vertex of triangle
-	vec3 v0 = WGS84ToECEF(vec3(vTPos2[0], getElev(uv0)));
-	vec3 v1 = WGS84ToECEF(vec3(vTPos2[1], getElev(uv1)));
-	vec3 v2 = WGS84ToECEF(vec3(vTPos2[2], getElev(uv2)));
-
 	// emit the vertices of the triangle to form the line
 	// strip from v0 -> v1 -> v2 -> v0
 
-	fPos = v0;
-	fLat = uv0.y;
-	gl_Position = MVPMat * vec4(fPos, 1.0);
+	fPos = vTLPos[0];
+	fLat = vTLat[0];
+	gl_Position = vTPos2[0];
 	EmitVertex();
 
-	fPos = v1;
-	fLat = uv1.y;
-	gl_Position = MVPMat * vec4(fPos, 1.0);
+	fPos = vTLPos[1];
+	fLat = vTLat[1];
+	gl_Position = vTPos2[1];
 	EmitVertex();
 
-	fPos = v2;
-	fLat = uv2.y;
-	gl_Position = MVPMat * vec4(fPos, 1.0);
-	EmitVertex();
-
-	fPos = v0;
-	fLat = uv0.y;
-	gl_Position = MVPMat * vec4(fPos, 1.0);
+	fPos = vTLPos[2];
+	fLat = vTLat[2];
+	gl_Position = vTPos2[2];
 	EmitVertex();
 	EndPrimitive();
+
+	fPos = vTLPos[0];
+	fLat = vTLat[0];
+	gl_Position = vTPos2[0];
+	EmitVertex();
 }

--- a/usr/modules/EarthTessellationModule/mm/shaders/earth.tesc
+++ b/usr/modules/EarthTessellationModule/mm/shaders/earth.tesc
@@ -51,7 +51,7 @@ vec3 WGS84ToECEF(vec3 v) {
 
 // sample elevation texture at UV coordinate
 float getElev(vec2 uv) {
-	return float(texture(elevationTexture, uv).r) * 10.0;
+	return float(texture(elevationTexture, uv).r) * 10.0; // exaggerate elevation by one magnitude of 10
 }
 
 // convert WGS84 to UV space of elevation texture

--- a/usr/modules/EarthTessellationModule/mm/shaders/earth.tese
+++ b/usr/modules/EarthTessellationModule/mm/shaders/earth.tese
@@ -57,14 +57,23 @@ float biLerp(float a, float b, float c, float d, float s, float t) {
 float biLerpTexture(vec2 uv, int level) {
 	ivec2 size = textureSize(elevationTexture, level);
 
-	float x = size.x * uv.x;
-	float y = size.y * uv.y;
+	// doing modulo here has the effect of repeat wrap.
+	// this is necessary if you try to access outside texture
+	// bounds. (clamp wouldn't be as appropriate here because the
+	// Earth is a sphere.)
+	float x = mod(size.x * uv.x, size.x);
+	float y = mod(size.y * uv.y, size.y);
 
 	int lx = int(floor(x));
-	int ux = int(ceil(x));
+	int ux = int(mod(ceil(x), size.x)); // need to do a mod here as well because rounding up could
+									    // result in an index outside the texture bounds
 
 	int ly = int(floor(y));
-	int uy = int(ceil(y));
+	int uy = int(mod(ceil(y), size.y)); // again, need to do a mod for rounding up
+
+	// Note: We don't need to do a mod for rounding down, because rounding down
+	//       on a number in the range [0, size) cannot result in a value outside
+	//       that range (because floor(0) = 0 and is a decreasing operation).
 
 	float e0 = float(texelFetch(elevationTexture, ivec2(lx, ly), level).r);
 	float e1 = float(texelFetch(elevationTexture, ivec2(ux, ly), level).r);

--- a/usr/modules/EarthTessellationModule/mm/shaders/earth.tese
+++ b/usr/modules/EarthTessellationModule/mm/shaders/earth.tese
@@ -9,7 +9,99 @@ layout (quads, fractional_odd_spacing, ccw) in;
 //       always be done.
 
 in vec2 vTPos[];
-out vec2 vTPos2;
+out vec3 vTLPos;
+out vec4 vTPos2;
+out float vTLat;
+
+uniform mat4 MVPMat;
+uniform float scale;
+uniform float maxTessellationFactor;
+
+uniform isampler2D elevationTexture;
+
+// constants used in conversion from WGS84
+const float EARTH_RADIUS = 6378137.0;
+const float EARTH_FLATTENING = 0.00669437999013;
+const float PI = 3.14159265358979323846;
+
+// convert from WGS84 to ECEF
+vec3 WGS84ToECEF(vec3 v) {
+	float latRad = v.x;
+	float lonRad = v.y;
+	float elev = v.z * scale;
+
+	float sinLatRad = sin(latRad);
+	float e2sinLatSq = EARTH_FLATTENING * (sinLatRad * sinLatRad);
+
+	float rn = EARTH_RADIUS * scale / sqrt(1 - e2sinLatSq);
+	float R = (rn + elev) * cos(latRad);
+
+	vec3 o;
+	o.x = R * cos(lonRad);
+	o.y = R * sin(lonRad);
+	o.z = (rn * (1 - EARTH_FLATTENING) + elev) * sin(latRad);
+
+	return o;
+}
+
+// bilinear interpolation
+float biLerp(float a, float b, float c, float d, float s, float t) {
+	float x = mix(a, b, s);
+	float y = mix(c, d, s);
+
+	return mix(x, y, t);
+}
+
+// sample elevation texture at given UV coordinate and level of detail,
+// but perform bilinear interpolation between texels
+float biLerpTexture(vec2 uv, int level) {
+	ivec2 size = textureSize(elevationTexture, level);
+
+	float x = size.x * uv.x;
+	float y = size.y * uv.y;
+
+	int lx = int(floor(x));
+	int ux = int(ceil(x));
+
+	int ly = int(floor(y));
+	int uy = int(ceil(y));
+
+	float e0 = float(texelFetch(elevationTexture, ivec2(lx, ly), level).r);
+	float e1 = float(texelFetch(elevationTexture, ivec2(ux, ly), level).r);
+	float e2 = float(texelFetch(elevationTexture, ivec2(lx, uy), level).r);
+	float e3 = float(texelFetch(elevationTexture, ivec2(ux, uy), level).r);
+
+	return biLerp(e0, e1, e2, e3, x - lx, y - ly);
+}
+
+// super-sample elevation texture at UV coordinate
+// note: The mipmap level used by this function is calculated based on
+//       the maxTessellationFactor. It interpolates between the upper and
+//       lower mipmap levels.
+float getElev(vec2 uv) {
+	// OpenGL max tessellation factor is 64. log2(64) = 6
+	// Thus, 6 - log2(64) = 0, so a maxTessellationFactor of 64 uses
+	// the base texture for sampling.
+	// A maxTessellationFactor of 16 uses mipmap level 2.
+	float level = clamp(6.0 - log2(maxTessellationFactor), 0.0, 6.0);
+	int lowLevel = int(floor(level));
+	int highLevel = int(ceil(level));
+	
+	float lowElev = biLerpTexture(uv, lowLevel);
+	float highElev = biLerpTexture(uv, highLevel);
+
+	float elev = mix(lowElev, highElev, level - lowLevel);
+
+	return elev * 10.0; // exaggerate elevation by one magnitude of 10
+}
+
+// convert WGS84 to UV space of elevation texture
+vec2 WGS84ToUV(vec2 v) {
+	vec2 uv;
+	uv.x = (v.y + PI) / (2 * PI);
+	uv.y = (PI / 2 - v.x) / PI;
+	return uv;
+}
 
 void main() {
 	float u = gl_TessCoord.x;
@@ -18,7 +110,14 @@ void main() {
 	// calculate tessellated interior vertex from tess coord uv
 	vec2 p0 = mix(vTPos[1], vTPos[2], u);
 	vec2 p1 = mix(vTPos[0], vTPos[3], u);
-	vec2 p = mix(p0, p1, v);
+	vec2 wgs = mix(p0, p1, v);
 
-	vTPos2 = p;
+	float level0 = mix(gl_TessLevelOuter[1], gl_TessLevelOuter[3], v);
+	float level1 = mix(gl_TessLevelOuter[0], gl_TessLevelOuter[2], u);
+	float level = max(level0, level1);
+	
+	vec2 uv = WGS84ToUV(wgs); // get UV coordinate for vertex
+	vTLPos = WGS84ToECEF(vec3(wgs, getElev(uv))); // get ECEF coordinate for vertex
+	vTPos2 = MVPMat * vec4(vTLPos, 1.0f); // transform into screen space
+	vTLat = uv.y; // send out the lattitude in uv space
 }

--- a/usr/modules/EarthTessellationModule/mm/shaders/earth_tri.geom
+++ b/usr/modules/EarthTessellationModule/mm/shaders/earth_tri.geom
@@ -2,96 +2,29 @@
 layout (triangles) in;
 layout (triangle_strip, max_vertices = 3) out;
 
-in vec2 vTPos2[];
+in vec3 vTLPos[];
+in vec4 vTPos2[];
+in float vTLat[];
 
 out vec3 fPos;
 out float fLat;
 
-uniform mat4 MVPMat;
-uniform float scale;
-
-uniform isampler2D elevationTexture;
-
-// constants used in conversion from WGS84
-const float EARTH_RADIUS = 6378137.0;
-const float EARTH_FLATTENING = 0.00669437999013;
-const float PI = 3.14159265358979323846;
-
-// convert from WGS84 to ECEF
-vec3 WGS84ToECEF(vec3 v) {
-	float latRad = v.x;
-	float lonRad = v.y;
-	float elev = v.z * scale;
-
-	float sinLatRad = sin(latRad);
-	float e2sinLatSq = EARTH_FLATTENING * (sinLatRad * sinLatRad);
-
-	float rn = EARTH_RADIUS * scale / sqrt(1 - e2sinLatSq);
-	float R = (rn + elev) * cos(latRad);
-
-	vec3 o;
-	o.x = R * cos(lonRad);
-	o.y = R * sin(lonRad);
-	o.z = (rn * (1 - EARTH_FLATTENING) + elev) * sin(latRad);
-
-	return o;
-}
-
-// super-sample elevation texture at UV coordinate
-float getElev(vec2 uv) {
-	float elev = 0;
-	float amntX = 1.0 / 64.0 / 180.0;
-	float amntY = amntX / 2.0;
-
-	// take 25 samples and average them
-	for (int i = 0; i < 5; ++i) {
-		for (int j = 0; j < 5; ++j) {
-			vec2 new_uv;
-			new_uv.x = uv.x + mix(-amntX, amntX, float(i) / 4.0);
-			new_uv.y = uv.y + mix(-amntY, amntY, float(j) / 4.0);
-
-			elev += float(textureLod(elevationTexture, new_uv, 10.0).r);
-		}
-	}
-	elev /= 25.0;
-
-	return elev * 10.0;
-}
-
-// convert WGS84 to UV space of elevation texture
-vec2 WGS84ToUV(vec2 v) {
-	vec2 uv;
-	uv.x = (v.y + PI) / (2 * PI);
-	uv.y = (PI / 2 - v.x) / PI;
-	return uv;
-}
-
 void main() {
-	// get UV coordinates for each vertex of triangle
-	vec2 uv0 = WGS84ToUV(vTPos2[0]);
-	vec2 uv1 = WGS84ToUV(vTPos2[1]);
-	vec2 uv2 = WGS84ToUV(vTPos2[2]);
-
-	// get ECEF coordinates for each vertex of triangle
-	vec3 v0 = WGS84ToECEF(vec3(vTPos2[0], getElev(uv0)));
-	vec3 v1 = WGS84ToECEF(vec3(vTPos2[1], getElev(uv1)));
-	vec3 v2 = WGS84ToECEF(vec3(vTPos2[2], getElev(uv2)));
-
 	// emit the vertices of the triangle
 
-	fPos = v0;
-	fLat = uv0.y;
-	gl_Position = MVPMat * vec4(fPos, 1.0);
+	fPos = vTLPos[0];
+	fLat = vTLat[0];
+	gl_Position = vTPos2[0];
 	EmitVertex();
 
-	fPos = v1;
-	fLat = uv1.y;
-	gl_Position = MVPMat * vec4(fPos, 1.0);
+	fPos = vTLPos[1];
+	fLat = vTLat[1];
+	gl_Position = vTPos2[1];
 	EmitVertex();
 
-	fPos = v2;
-	fLat = uv2.y;
-	gl_Position = MVPMat * vec4(fPos, 1.0);
+	fPos = vTLPos[2];
+	fLat = vTLat[2];
+	gl_Position = vTPos2[2];
 	EmitVertex();
 	EndPrimitive();
 }


### PR DESCRIPTION
Finally figured out how to manually do mipmapping for integer textures (because OpenGL doesn't appear to have built in support for it), which serves as a replacement for the slow super-sampling I was doing in the shaders.